### PR TITLE
Fix #4 and other bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,4 +28,4 @@ If applicable, add screenshots to help explain your problem.
  - Browser [e.g. chrome, safari]
 
 **Additional context**
-Add any other context about the problem here.
+Add any other context about the problem here. This includes any errors in the browser or node console, as these are VERY importiant to help find issues!

--- a/client/src/components/login.vue
+++ b/client/src/components/login.vue
@@ -7,7 +7,7 @@
         <div id="login-error-msg-holder">
           <p
             id="login-error-msg"
-            v-if="message.includes(403)"
+            v-if="!message.includes(200)"
             style="color: red"
           >
             {{ message }}
@@ -87,8 +87,9 @@ export default {
             this.$store.commit("changeUser", data.data);
             this.$router.push("/home");
           })
-          .catch(() => {
-            this.message = "Incorrect Username or Password (403)";
+          .catch((err) => {
+            if (err.toString().includes('403')) this.message = "Incorrect Username or Password (403)"
+            else {this.message = err.toString(), console.log('msg: ', this.message)}
           });
       }
     }

--- a/client/src/services/loginService.ts
+++ b/client/src/services/loginService.ts
@@ -1,12 +1,12 @@
 import axios from "axios";
 import config from "../../../app/config.json";
 
-const BASE_URL = `${config.server.host}/api/`;
+const BASE_URL = `${config.server.host}`;
 
 class LoginService {
   static async login(username: string, password: string) {
     return axios
-      .post(BASE_URL + "login/", {
+      .post(BASE_URL + "/api/login/", {
         username: username,
         password: password
       })


### PR DESCRIPTION
 - Fixed #4, adding a `authUser` function that returns a promise. If resolved, the promise will return the old `loggedUser` var, containing user data. If rejected, it will return the HTTP status code (403)

- Added a bug report note about including console errors in issues if applicable

- Changed error text to show red if it's not 200, rather than if it's 403; to support all non-403 errors to be displayed, which was also added (Incase a 500 occurs, it can be displayed there)

- Fixed API route so base URL dosnt include /api, and moved it down to when the URL is actually used (with "/login")

- Fixed paths in upload.ts that were changes as a result of #2 